### PR TITLE
Fix get_descendants_queryset bug

### DIFF
--- a/treenode/models.py
+++ b/treenode/models.py
@@ -253,7 +253,7 @@ class TreeNodeModel(with_metaclass(TreeFactory, models.Model)):
         """Get the descendants queryset"""
 
         pks = self.get_descendants_pks(include_self, depth)
-        return self._meta.model.objects.filter(**pks)
+        return self._meta.model.objects.filter(pk__in=pks)
 
     def get_descendants_tree(self):
         """Get a n-dimensional dict representing the model tree"""


### PR DESCRIPTION
This will fix up the error below.

  File "C:\Dev\prime-github\venv\Lib\site-packages\treenode\models.py", line 256, in get_descendants_queryset
    return self._meta.model.objects.filter(**pks)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: django.db.models.query.QuerySet.filter() argument after ** must be a mapping, not list