### PR TITLE
Fix dropdown clipping in TreeWidget

### DIFF
--- a/treenode/static/treenode/css/tree_widget.css
+++ b/treenode/static/treenode/css/tree_widget.css
@@ -40,6 +40,13 @@ Email: timurkady@yandex.com
     z-index: auto;
 }
 
+/* Ensure dropdowns are not clipped when the widget is used for
+ * fields other than 'parent'. This class will be added dynamically
+ * by tree_widget.js to the widget's parent .form-row container. */
+.form-row.treenode-visible {
+    overflow: visible !important;
+}
+
 .tree-widget {
     position: relative;
     width: 100%;

--- a/treenode/static/treenode/js/tree_widget.js
+++ b/treenode/static/treenode/js/tree_widget.js
@@ -27,6 +27,13 @@ Email: timurkady@yandex.com
       $(selector).each(function () {
         var $widget = $(this);
 
+        // Make sure the widget's parent form row allows overflow so
+        // that the dropdown menu is not clipped.
+        var $formRow = $widget.closest('.form-row');
+        if ($formRow.length) {
+          $formRow.addClass('treenode-visible');
+        }
+
         // Find the hidden input, dropdown list and display area inside
         // the container
         var $select = $widget.find('input[type="hidden"]').first();


### PR DESCRIPTION
## Summary
- ensure the tree widget dropdown is not hidden inside `.form-row`
- add new CSS class `treenode-visible` and apply it when initializing the widget

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686ff3fa05c48330a6ac8ec44eb1456b