### PR TITLE
Fix stale data issues in tree cache and admin views

### DIFF
--- a/treenode/admin/admin.py
+++ b/treenode/admin/admin.py
@@ -151,7 +151,6 @@ class TreeNodeModelAdmin(AdminMixin, admin.ModelAdmin):
         """Get queryset."""
         qs = super().get_queryset(request)
         return qs.select_related('parent')\
-            .prefetch_related('children')\
             .order_by('_path')
 
     def get_list_display(self, request):

--- a/treenode/views/children.py
+++ b/treenode/views/children.py
@@ -33,7 +33,7 @@ class TreeChildrenView(View):
                 "level": node.get_depth(),
                 "is_leaf": node.is_leaf(),
             }
-            for node in obj.get_children()
+            for node in obj.get_children_queryset()
         ]
         return JsonResponse({"results": results})
 


### PR DESCRIPTION
## Summary
This PR addresses stale data issues in the TreeCache system and admin views by improving cache invalidation, removing unnecessary prefetch operations, and using direct queryset queries instead of cached methods.

## Key Changes

- **Cache invalidation improvements** (`treenode/cache.py`):
  - Clean `queue_index` after moving items from queue to cache to prevent stale references
  - Properly clean `queue_index` during `invalidate()` calls to remove all keys matching the invalidated prefix
  - Clear `queue_index` in `clear()` method for complete cache reset
  - Updated docstring to reflect that both queue and queue_index are purged during invalidation

- **Admin queryset optimization** (`treenode/admin/admin.py`):
  - Removed unnecessary `prefetch_related('children')` from the admin list view queryset
  - Reduces memory overhead and potential stale data issues

- **Admin AJAX view fix** (`treenode/admin/mixin.py`):
  - Changed from using cached `get_children()` method to direct queryset query
  - Bypasses `@cached_method` decorator to avoid serving stale data from TreeCache
  - Uses `filter(parent_id=parent_id)` with `select_related('parent')` and `order_by('_path')` for consistent, fresh data

- **Children API view fix** (`treenode/views/children.py`):
  - Changed from `get_children()` to `get_children_queryset()` to avoid cached data
  - Ensures API responses reflect current tree state

## Implementation Details
The root cause was that cached methods could return stale data when the tree structure changed. By using direct queryset queries in user-facing views and properly maintaining cache indexes, we ensure data consistency while still benefiting from caching where appropriate.

https://claude.ai/code/session_01CTErsDGcraB3duENodRQWN