### PR TITLE
docs(admin): clarify changelist expand/collapse is client-side, not AJAX lazy-load

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -21,23 +21,24 @@ class CategoryAdmin(TreeNodeModelAdmin):
     search_fields = ("name",)
 ```
 
-The tree structure in the admin panel **loads dynamically as nodes are expanded**. This allows handling **large datasets** efficiently, preventing performance issues.
+The changelist renders the full tree on the initial request and **expands or collapses nodes on the client without additional AJAX calls**. All nodes for the current changelist page are already in the DOM; the accordion only toggles their visibility.
 
 TreeNode uses `_path` as the canonical tree order in admin responses and queryset traversal, so nodes are rendered in hierarchical order consistently.
 
 You can choose from three display modes:
 
-- **`TREENODE_DISPLAY_MODE_ACCORDION` (default)**  
-  Expands/collapses nodes dynamically.
-- **`TREENODE_DISPLAY_MODE_BREADCRUMBS`**  
+- **`TREENODE_DISPLAY_MODE_ACCORDION` (default)**
+  Toggles client-side expand/collapse of already-rendered nodes.
+- **`TREENODE_DISPLAY_MODE_BREADCRUMBS`**
   Displays the tree as a sequence of **breadcrumbs**, making it easy to navigate.
 
 The accordion mode is **always active**, and the setting only affects how nodes are displayed.
 
-**Why Dynamic Loading**:  Traditional pagination does not work well for **deep hierarchical trees**, as collapsed trees may contain a **huge number of nodes**, which is in the hundreds of thousands. The dynamic approach allows efficient loading, reducing database load while keeping large trees manageable.
+> **Note**
+> Earlier versions of this page described lazy-loading of children over AJAX. That is not the shipped behavior: the changelist does not lazy-load tree nodes from the server, so the full page is still bounded by Django's standard changelist pagination. Lazy-loading of tree nodes in the changelist is tracked as a separate feature request.
 
 #### Search Functionality
-The search bar helps quickly locate nodes within large trees. As you type, **an AJAX request retrieves up to 20 results** based on relevance. If you don’t find the desired node, keep typing to refine the search until fewer than 20 results remain.
+The search bar helps quickly locate nodes within large trees. As you type, **an AJAX request retrieves up to 20 results** based on relevance. If you don't find the desired node, keep typing to refine the search until fewer than 20 results remain. The search endpoint is one of the places where the admin does use AJAX; the changelist expand/collapse described above does not.
 
 ### Working with Forms
 


### PR DESCRIPTION
Closes #33.

The `TreeNodeModelAdmin` section in `docs/admin.md` told users the changelist "loads dynamically as nodes are expanded" and pitched dynamic loading as a solution for "hundreds of thousands" of nodes. The shipped behavior is just client-side accordion expand/collapse of already-rendered nodes; nothing in `treenode_admin.js` makes an AJAX request to fetch children when a node is opened.

This PR keeps the section short and aligned with the shipped behavior, separates the two cases the issue author and maintainer asked for (changelist expand/collapse without AJAX, vs. search where AJAX is used), and leaves the door open to future lazy-loading as a separate feature.

Maintainer endorsement on the issue:
> Thanks, you're right: the current documentation in the TreeNodeModelAdmin section is misleading. At the moment, the admin does not lazy-load children via AJAX; "dynamic" there only means client-side expand/collapse (show/hide of already-rendered nodes).
> ...
> I'll update the docs to clearly separate:
> - expand/collapse in the changelist without AJAX, and
> - places where AJAX is used (search/widgets).
>
> -- @TimurKady (owner), https://github.com/TimurKady/django-fast-treenode/issues/33#issuecomment-3860583737